### PR TITLE
Fix Medium blog post descriptions rendering

### DIFF
--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -29,6 +29,7 @@ const BlogSection: FC<BlogSectionProps> = ({ posts, isFetching, onRetry }) => (
           });
 
           let excerpt = post.description || post.content || '';
+          excerpt = excerpt.replace(/<[^>]*>/g, '');
           if (excerpt.length > 150) {
             excerpt = excerpt.substring(0, 150) + '...';
           }

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -66,9 +66,7 @@ const ChartContainer = React.forwardRef<
 ChartContainer.displayName = "Chart"
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
-  const colorConfig = Object.entries(config).filter(
-    ([_, config]) => config.theme || config.color
-  )
+  const colorConfig = Object.entries(config).filter(([, itemConfig]) => itemConfig.theme || itemConfig.color)
 
   if (!colorConfig.length) {
     return null


### PR DESCRIPTION
## Summary
- sanitize Medium post excerpts by stripping HTML tags before truncating
- adjust chart utility to avoid unused variable warning

## Testing
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c444238f708326a29afe51eb55a183