### PR TITLE
chore: speed up navigation transitions

### DIFF
--- a/src/artifact-component.tsx
+++ b/src/artifact-component.tsx
@@ -19,7 +19,6 @@ import { MediumPost } from './types';
 
 const ArtifactComponent = () => {
   const [activeTab, setActiveTab] = useState('home');
-  const [isLoading, setIsLoading] = useState(false);
   const [isHired, setIsHired] = useState(false);
   const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
   const [mediumPosts, setMediumPosts] = useState<MediumPost[]>([]);
@@ -148,14 +147,10 @@ const ArtifactComponent = () => {
   const handleTabClick = useCallback(
     (tab: string) => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
-      setIsLoading(true);
-      setTimeout(() => {
-        setActiveTab(tab);
-        setIsLoading(false);
-        if (tab === 'blog' && mediumPosts.length === 0) {
-          fetchMediumPosts();
-        }
-      }, 200);
+      setActiveTab(tab);
+      if (tab === 'blog' && mediumPosts.length === 0) {
+        fetchMediumPosts();
+      }
     },
     [mediumPosts, fetchMediumPosts]
   );
@@ -181,14 +176,6 @@ const ArtifactComponent = () => {
         className="container mx-auto px-6 py-12 relative z-20"
       >
         <Navigation activeTab={activeTab} onTabClick={handleTabClick} />
-        {isLoading && (
-          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 backdrop-blur-sm">
-            <div className="text-center">
-              <div className="spinner border-4 border-gray-300 border-t-cyan-400 rounded-full w-12 h-12 animate-spin mx-auto mb-4"></div>
-              <p className="text-white text-lg animate-pulse">Loading next dimension...</p>
-            </div>
-          </div>
-        )}
         {activeTab === 'home' && (
           <HomeSection
             onHireClick={handleHireNavigate}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -15,7 +15,7 @@ const Navigation: FC<NavigationProps> = ({ activeTab, onTabClick }) => (
         type="button"
         onClick={() => onTabClick(tab)}
         aria-current={activeTab === tab ? 'page' : undefined}
-        className={`tab px-6 py-3 rounded-lg font-bold transition-all duration-300 border-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 ${
+        className={`tab px-6 py-3 rounded-lg font-bold transition-all duration-200 ease-out motion-reduce:transition-none border-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 ${
           activeTab === tab
             ? 'text-green-400 border-green-400 bg-green-400/20 shadow-lg shadow-green-400/30'
             : 'text-gray-400 border-gray-600 hover:border-cyan-400 hover:text-cyan-400'


### PR DESCRIPTION
## Summary
- Drop artificial loading delay so section switches happen instantly
- Snappier navigation buttons with shorter transitions and reduced-motion support

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c454d1d55083269547c0605903e336