### PR TITLE
feat: improve Calendly link security

### DIFF
--- a/src/artifact-component.tsx
+++ b/src/artifact-component.tsx
@@ -158,7 +158,7 @@ const ArtifactComponent = () => {
   const handleHireNavigate = useCallback(() => handleTabClick('contact'), [handleTabClick]);
 
   const bookMeeting = useCallback(() => {
-    window.open('https://calendly.com/abirabbasmd', '_blank');
+    window.open('https://calendly.com/abirabbasmd', '_blank', 'noopener,noreferrer');
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- ensure Calendly meeting link opens without window.opener access

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c4654837048326a93cbf30971b3868