### PR TITLE
feat: secure proxy with validation and rate limiting

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 MONGODB_URI=mongodb+srv://knowHow71:5GbBN8gGcfQjiJCe@cluster0.mongodb.net/myFirstDatabase?retryWrites=true&w=majority
+GOOGLE_APPS_SCRIPT_URL=https://script.google.com/macros/s/AKfycbzDth9_t9bR01hJv4-Q8Tg_raQcUkQnUff5uUDh6gb06C7fhTbzYWvJ-i5hdn7Rk2Gj/exec

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "dotenv": "^16.4.7",
     "embla-carousel-react": "^8.1.6",
     "express": "^4.21.2",
+    "express-rate-limit": "^8.1.0",
     "framer-motion": "^12.23.12",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.408.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2498,6 +2498,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^4.6.2"
     eslint-plugin-react-refresh: "npm:^0.4.7"
     express: "npm:^4.21.2"
+    express-rate-limit: "npm:^8.1.0"
     framer-motion: "npm:^12.23.12"
     glob: "npm:^10.4.5"
     input-otp: "npm:^1.2.4"
@@ -3493,6 +3494,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-rate-limit@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "express-rate-limit@npm:8.1.0"
+  dependencies:
+    ip-address: "npm:10.0.1"
+  peerDependencies:
+    express: ">= 4.11"
+  checksum: 10c0/3bb7aa646f9b79ce4e8e0a683d1c200b5d393fed60c3ecda13748fc351a9ee822436e9eeb2cbb2f5da4aae2f94fe4aafad9b679468861a8cc2bb9cd812bc102b
+  languageName: node
+  linkType: hard
+
 "express@npm:^4.21.2":
   version: 4.21.2
   resolution: "express@npm:4.21.2"
@@ -4042,7 +4054,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.0.1":
+"ip-address@npm:10.0.1, ip-address@npm:^10.0.1":
   version: 10.0.1
   resolution: "ip-address@npm:10.0.1"
   checksum: 10c0/1634d79dae18394004775cb6d699dc46b7c23df6d2083164025a2b15240c1164fccde53d0e08bd5ee4fc53913d033ab6b5e395a809ad4b956a940c446e948843


### PR DESCRIPTION
## Summary
- restrict proxy to POST requests from https://your-domain.com and add rate limiting
- validate request payload schema and forward to Google Apps Script via environment variable

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68c46738f09c832680491bc4d8769e4b