### PR TITLE
Add Content Security Policy meta tag and server security headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAGXRFWHRTb2Z0d2FyZQBNYWNpbnRvc2ggSEQgdjEuOTAg4Baq2gAAAD9JREFUKFNjZGBgYGBgUggUGBoa/N8BgwERnLx9uZkBlJDAyMjKAkYEHETVzkKACGcEAMON0IxtZG6XAAAAAElFTkSuQmCC" type="image/png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https:; object-src 'none'; frame-ancestors 'none'">
     <meta name="description" content="Portfolio of Mohammad Abir Abbas – AI developer, Rust enthusiast and security specialist building AI-powered, secure and scalable solutions." />
     <meta name="keywords" content="Mohammad Abir Abbas, AI developer, Rust, security, portfolio" />
     <meta name="author" content="Mohammad Abir Abbas" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,5 +12,21 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
       'src': path.resolve(__dirname, './src'),
     },
-  }
+  },
+  server: {
+    headers: {
+      'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'Referrer-Policy': 'no-referrer',
+    },
+  },
+  preview: {
+    headers: {
+      'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
+      'X-Content-Type-Options': 'nosniff',
+      'X-Frame-Options': 'DENY',
+      'Referrer-Policy': 'no-referrer',
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- enforce strict Content Security Policy via `<meta http-equiv="Content-Security-Policy" ...>`
- configure Vite dev and preview servers to send security headers (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy)

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68c46948abd4832698e6a4347b29c5ba