### PR TITLE
refactor: secure CSP while supporting Medium feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Strive for a fast, fluid experience:
 - Maintain **60 fps** scrolling without layout shifts
 
 Track these metrics with real user monitoring and adjust assets, code splitting and caching accordingly.
+
+## Security
+
+The project sets a restrictive Content Security Policy in `index.html` that allows only the resources needed to fetch and display Medium posts. Configure `frame-ancestors` via your hosting platform's HTTP headers for full protection.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAGXRFWHRTb2Z0d2FyZQBNYWNpbnRvc2ggSEQgdjEuOTAg4Baq2gAAAD9JREFUKFNjZGBgYGBgUggUGBoa/N8BgwERnLx9uZkBlJDAyMjKAkYEHETVzkKACGcEAMON0IxtZG6XAAAAAElFTkSuQmCC" type="image/png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https:; object-src 'none'; frame-ancestors 'none'">
+    <!-- frame-ancestors must be delivered via HTTP headers -->
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn-images-1.medium.com https://miro.medium.com; connect-src 'self' https://api.rss2json.com; object-src 'none'; base-uri 'self'"
+    />
     <meta name="description" content="Portfolio of Mohammad Abir Abbas – AI developer, Rust enthusiast and security specialist building AI-powered, secure and scalable solutions." />
     <meta name="keywords" content="Mohammad Abir Abbas, AI developer, Rust, security, portfolio" />
     <meta name="author" content="Mohammad Abir Abbas" />

--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -1,4 +1,5 @@
 import { FC, memo } from 'react';
+import DOMPurify from 'dompurify';
 import { MediumPost } from '../types';
 
 interface BlogSectionProps {
@@ -29,7 +30,7 @@ const BlogSection: FC<BlogSectionProps> = ({ posts, isFetching, onRetry }) => (
           });
 
           let excerpt = post.description || post.content || '';
-          excerpt = excerpt.replace(/<[^>]*>/g, '');
+          excerpt = DOMPurify.sanitize(excerpt, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
           if (excerpt.length > 150) {
             excerpt = excerpt.substring(0, 150) + '...';
           }


### PR DESCRIPTION
## Summary
- refine Content-Security-Policy to permit Medium images and RSS requests
- sanitize Medium RSS excerpts with DOMPurify
- document CSP considerations for deployment

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68c475845de08326894805f35cf871c6