### PR TITLE
Move Content-Security-Policy to HTTP headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAMCAYAAABWdVznAAAAGXRFWHRTb2Z0d2FyZQBNYWNpbnRvc2ggSEQgdjEuOTAg4Baq2gAAAD9JREFUKFNjZGBgYGBgUggUGBoa/N8BgwERnLx9uZkBlJDAyMjKAkYEHETVzkKACGcEAMON0IxtZG6XAAAAAElFTkSuQmCC" type="image/png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- frame-ancestors must be delivered via HTTP headers -->
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn-images-1.medium.com https://miro.medium.com; connect-src 'self' https://api.rss2json.com; object-src 'none'; base-uri 'self'"
-    />
     <meta name="description" content="Portfolio of Mohammad Abir Abbas – AI developer, Rust enthusiast and security specialist building AI-powered, secure and scalable solutions." />
     <meta name="keywords" content="Mohammad Abir Abbas, AI developer, Rust, security, portfolio" />
     <meta name="author" content="Mohammad Abir Abbas" />

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,30 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "no-referrer"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn-images-1.medium.com https://miro.medium.com; connect-src 'self' https://api.rss2json.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self'"
+        }
+      ]
+    }
+  ]
+}
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Referrer-Policy': 'no-referrer',
+      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn-images-1.medium.com https://miro.medium.com; connect-src 'self' https://api.rss2json.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self'",
     },
   },
   preview: {
@@ -27,6 +28,7 @@ export default defineConfig({
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Referrer-Policy': 'no-referrer',
+      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn-images-1.medium.com https://miro.medium.com; connect-src 'self' https://api.rss2json.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self'",
     },
   },
 });


### PR DESCRIPTION
## Summary
- remove inline CSP meta tag from `index.html`
- serve Content-Security-Policy via Vite dev/preview headers
- add `vercel.json` so production hosting sends same security headers

## Testing
- `yarn lint`
- `yarn build`
- `yarn test` *(fails: Couldn't find a script named "test")*
- `curl -I http://localhost:4173`

------
https://chatgpt.com/codex/tasks/task_e_68c47a3990608326bb214ffe00137d0d