### PR TITLE
Limit tutorials to 5 videos and allow YouTube thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Track these metrics with real user monitoring and adjust assets, code splitting 
 
 ## Security
 
-The project sets a restrictive Content Security Policy in `index.html` that allows only the resources needed to fetch and display Medium posts. Configure `frame-ancestors` via your hosting platform's HTTP headers for full protection.
+The project sets a restrictive Content Security Policy in `index.html` that allows only the resources needed to fetch and display Medium posts and YouTube thumbnails. Configure `frame-ancestors` via your hosting platform's HTTP headers for full protection.
 
 ## Tutorials
 

--- a/src/components/TutorialsSection.tsx
+++ b/src/components/TutorialsSection.tsx
@@ -27,7 +27,7 @@ const TutorialsSection: FC = () => {
       if (!API_KEY) return;
       try {
         const res = await fetch(
-          `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=50&playlistId=${PLAYLIST_ID}&key=${API_KEY}`,
+          `https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&maxResults=5&playlistId=${PLAYLIST_ID}&key=${API_KEY}`,
         );
         const data: YouTubePlaylistItemsResponse = await res.json();
         setVideos(
@@ -39,7 +39,8 @@ const TutorialsSection: FC = () => {
               if (!id || !title || !thumbnail) return null;
               return { id, title, thumbnail };
             })
-            .filter((v): v is Video => v !== null),
+            .filter((v): v is Video => v !== null)
+            .slice(0, 5),
         );
       } catch (err) {
         console.error('Failed to load videos', err);
@@ -71,6 +72,16 @@ const TutorialsSection: FC = () => {
             <h3 className="mt-2 text-lg text-gray-200 group-hover:text-cyan-400">{video.title}</h3>
           </a>
         ))}
+      </div>
+      <div className="text-center mt-8">
+        <a
+          href={`https://www.youtube.com/playlist?list=${PLAYLIST_ID}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block bg-gradient-to-r from-cyan-500 to-green-500 hover:from-cyan-600 hover:to-green-600 text-black font-bold py-3 px-6 rounded-lg border-2 border-transparent transition-all duration-300 text-shadow-glow transform hover:scale-105 hover:shadow-lg hover:shadow-green-400/30"
+        >
+          View All Tutorials on YouTube →
+        </a>
       </div>
     </section>
   );

--- a/vercel.json
+++ b/vercel.json
@@ -21,7 +21,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn-images-1.medium.com https://miro.medium.com; connect-src 'self' https://api.rss2json.com https://www.googleapis.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn-images-1.medium.com https://miro.medium.com https://i.ytimg.com https://img.youtube.com; connect-src 'self' https://api.rss2json.com https://www.googleapis.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com"
         }
       ]
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Referrer-Policy': 'no-referrer',
-      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn-images-1.medium.com https://miro.medium.com; connect-src 'self' https://api.rss2json.com https://www.googleapis.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
+      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn-images-1.medium.com https://miro.medium.com https://i.ytimg.com https://img.youtube.com; connect-src 'self' https://api.rss2json.com https://www.googleapis.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
     },
   },
   preview: {
@@ -28,7 +28,7 @@ export default defineConfig({
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Referrer-Policy': 'no-referrer',
-      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn-images-1.medium.com https://miro.medium.com; connect-src 'self' https://api.rss2json.com https://www.googleapis.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
+      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn-images-1.medium.com https://miro.medium.com https://i.ytimg.com https://img.youtube.com; connect-src 'self' https://api.rss2json.com https://www.googleapis.com; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",
     },
   },
 });


### PR DESCRIPTION
## Summary
- limit tutorial playlist to five recent videos and offer a link to the full YouTube playlist
- extend Content Security Policy to allow YouTube thumbnail domains
- document CSP update in README

## Testing
- `yarn lint`
- `yarn build && echo build-ok`


------
https://chatgpt.com/codex/tasks/task_e_68c49ee48f188326aaca8e2649c47fb8