### PR TITLE
Add awards section with concise achievements

### DIFF
--- a/src/artifact-component.tsx
+++ b/src/artifact-component.tsx
@@ -11,6 +11,7 @@ import ServicesSection from './components/ServicesSection';
 import JourneySection from './components/JourneySection';
 import ContactSection from './components/ContactSection';
 import ExperienceSection from './components/ExperienceSection';
+import AwardsSection from './components/AwardsSection';
 
 import { skills } from './data/skills';
 import { projects } from './data/projects';
@@ -18,6 +19,7 @@ import { services } from './data/services';
 import { linkedinRecommendations } from './data/linkedin-recommendations';
 import { journey } from './data/journey';
 import { experiences } from './data/experience';
+import { awards } from './data/awards';
 import { MediumPost } from './types';
 
 const ArtifactComponent = () => {
@@ -195,6 +197,7 @@ const ArtifactComponent = () => {
         {activeTab === 'services' && (
           <ServicesSection services={services} bookMeeting={bookMeeting} />
         )}
+        {activeTab === 'awards' && <AwardsSection awards={awards} />}
         {activeTab === 'experience' && <ExperienceSection experiences={experiences} />}
         {activeTab === 'journey' && <JourneySection journey={journey} />}
         {activeTab === 'contact' && <ContactSection bookMeeting={bookMeeting} />}

--- a/src/components/AwardsSection.tsx
+++ b/src/components/AwardsSection.tsx
@@ -1,0 +1,56 @@
+import { FC, memo } from 'react';
+import { Award } from '../data/awards';
+
+interface AwardsSectionProps {
+  awards: Award[];
+}
+
+const AwardsSection: FC<AwardsSectionProps> = ({ awards }) => (
+  <section className="mb-16 animate-fadeIn">
+    <h2 className="text-4xl font-bold text-center mb-12 bg-gradient-to-r from-green-400 to-cyan-400 bg-clip-text text-transparent">
+      Awards &amp; Certifications
+    </h2>
+
+    <div className="max-w-5xl mx-auto grid gap-8">
+      {awards.map((award, index) => (
+        <article
+          key={`${award.title}-${index}`}
+          className="bg-white/5 border border-white/10 rounded-2xl p-6 shadow-lg shadow-cyan-500/10 hover:shadow-cyan-500/30 transition-shadow duration-300"
+        >
+          <header className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-4">
+            <div>
+              <h3 className="text-2xl font-semibold text-green-400">{award.title}</h3>
+              <p className="text-gray-300">
+                <span className="text-cyan-300">{award.issuer}</span>
+                {award.date && <span className="text-gray-400"> · {award.date}</span>}
+              </p>
+            </div>
+            {award.link && (
+              <a
+                href={award.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="self-start inline-flex items-center gap-2 text-sm font-semibold text-cyan-300 hover:text-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0d1321]"
+              >
+                View credential
+                <span aria-hidden>↗</span>
+              </a>
+            )}
+          </header>
+
+          {award.description && <p className="text-gray-300 leading-relaxed mb-4">{award.description}</p>}
+
+          {award.highlights && award.highlights.length > 0 && (
+            <ul className="list-disc list-inside text-gray-300 space-y-2">
+              {award.highlights.map((highlight, highlightIndex) => (
+                <li key={highlightIndex}>{highlight}</li>
+              ))}
+            </ul>
+          )}
+        </article>
+      ))}
+    </div>
+  </section>
+);
+
+export default memo(AwardsSection);

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -5,7 +5,7 @@ interface NavigationProps {
   onTabClick: (tab: string) => void;
 }
 
-const tabs = ['home', 'skills', 'projects', 'blog', 'tutorials', 'services', 'experience', 'journey', 'contact'];
+const tabs = ['home', 'skills', 'projects', 'blog', 'tutorials', 'services', 'awards', 'experience', 'journey', 'contact'];
 
 const Navigation: FC<NavigationProps> = ({ activeTab, onTabClick }) => (
   <nav className="flex flex-wrap justify-center gap-4 mb-12" aria-label="Primary">

--- a/src/data/awards.ts
+++ b/src/data/awards.ts
@@ -1,0 +1,56 @@
+export interface Award {
+  title: string;
+  issuer: string;
+  date?: string;
+  description?: string;
+  highlights?: string[];
+  link?: string;
+}
+
+export const awards: Award[] = [
+  {
+    title: 'Wolfsburg Homie',
+    issuer: '42 Wolfsburg',
+    description: 'Awarded for embracing the 42 Wolfsburg community spirit—complete with legendary late-night coding sessions.',
+    highlights: ['A playful nod for “sleeping too much” while still shipping code.']
+  },
+  {
+    title: 'Redis Side Quest Hackathon Winner',
+    issuer: 'Redis',
+    description: 'Built RedAGPT, an agentic network security assistant, to win the Redis Side Quest hackathon challenge.',
+    highlights: ['Showcased innovative use of agents to strengthen network security workflows.']
+  },
+  {
+    title: 'Certificate of Achievement',
+    issuer: 'Local Committee Hannover, AIESEC',
+    date: 'Sep 2022',
+    description: 'Recognized for leading the iGTA program with the highest number of completed actions.'
+  },
+  {
+    title: 'Certificate of Appreciation',
+    issuer: 'Local Committee Hannover, AIESEC',
+    date: 'Sep 2022',
+    description: 'Honored for activating leadership and empowering peers within the AIESEC network.'
+  },
+  {
+    title: 'DigComp Digital Competence Certification',
+    issuer: 'Joint Research Centre, European Commission (DigComp)',
+    date: 'Sep 2022',
+    description:
+      'Validated proficiency across the European Union\'s five digital competence pillars, demonstrating critical, confident, and responsible engagement in digital spaces.',
+    highlights: [
+      'Combined recognition covering the Certificate of Proficiency in Digital Competence and the Digital Skills Assessment (DigComp).'
+    ],
+    link: 'https://joint-research-centre.ec.europa.eu/digcomp_en'
+  },
+  {
+    title: 'Goethe-Institut A2 German Certification',
+    issuer: 'Goethe-Institut',
+    date: 'Aug 2019',
+    highlights: [
+      'Demonstrated command of everyday expressions and practical sentences in German.',
+      'Capable of managing routine conversations and sharing essential personal information.',
+      'Established a solid linguistic base for continued study and cultural collaboration.'
+    ]
+  }
+];


### PR DESCRIPTION
## Summary
- add an awards dataset and dedicated section to present key achievements succinctly
- wire the awards tab into the artifact navigation so the new section is accessible from the UI
- prioritize the Wolfsburg Homie and Redis hackathon wins at the top of the awards listing

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68c94accc85c83269789b4d12c5590cf