### PR TITLE
Update Instagram handle for social highlights

### DIFF
--- a/src/artifact-component.tsx
+++ b/src/artifact-component.tsx
@@ -6,6 +6,7 @@ import HomeSection from './components/HomeSection';
 import SkillsSection from './components/SkillsSection';
 import ProjectsSection from './components/ProjectsSection';
 import BlogSection from './components/BlogSection';
+import SocialPhotosSection from './components/SocialPhotosSection';
 import TutorialsSection from './components/TutorialsSection';
 import ServicesSection from './components/ServicesSection';
 import JourneySection from './components/JourneySection';
@@ -21,6 +22,7 @@ import { linkedinRecommendations } from './data/linkedin-recommendations';
 import { journey } from './data/journey';
 import { experiences } from './data/experience';
 import { awards } from './data/awards';
+import { socialPhotos } from './data/social-photos';
 import { MediumPost } from './types';
 
 const ArtifactComponent = () => {
@@ -194,6 +196,7 @@ const ArtifactComponent = () => {
         {activeTab === 'blog' && (
           <BlogSection posts={mediumPosts} isFetching={isFetchingPosts} onRetry={fetchMediumPosts} />
         )}
+        {activeTab === 'social' && <SocialPhotosSection platforms={socialPhotos} />}
         {activeTab === 'tutorials' && <TutorialsSection />}
         {activeTab === 'services' && (
           <ServicesSection services={services} bookMeeting={bookMeeting} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -11,6 +11,7 @@ const tabs = [
   'skills',
   'projects',
   'blog',
+  'social',
   'tutorials',
   'services',
   'awards',

--- a/src/components/SocialPhotosSection.tsx
+++ b/src/components/SocialPhotosSection.tsx
@@ -1,0 +1,131 @@
+import { FC, memo, useMemo } from 'react';
+import type { SocialPlatformPhotos, SocialPhoto } from '../data/social-photos';
+
+interface SocialPhotosSectionProps {
+  platforms: SocialPlatformPhotos[];
+}
+
+const formatDate = (timestamp: string) => {
+  try {
+    return new Intl.DateTimeFormat('en', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    }).format(new Date(timestamp));
+  } catch (error) {
+    console.error('Error formatting timestamp', error);
+    return '';
+  }
+};
+
+const platformColor: Record<SocialPhoto['platform'], string> = {
+  facebook: 'from-[#1877f2]/70 to-[#0e4aa3]/70',
+  instagram: 'from-[#f77737]/70 via-[#e4405f]/70 to-[#8a3ab9]/70'
+};
+
+const SocialPhotosSection: FC<SocialPhotosSectionProps> = ({ platforms }) => {
+  const sortedPlatforms = useMemo(
+    () =>
+      platforms.map((platform) => ({
+        ...platform,
+        photos: [...platform.photos].sort(
+          (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+        )
+      })),
+    [platforms]
+  );
+
+  return (
+    <section className="mb-16 animate-fadeIn">
+      <div className="text-center mb-12">
+        <h2 className="text-4xl font-bold bg-gradient-to-r from-[#c8fff4] via-[#4DB6AC] to-[#009688] bg-clip-text text-transparent drop-shadow-[0_16px_40px_rgba(0,150,136,0.25)]">
+          Social Highlights
+        </h2>
+        <p className="mt-4 max-w-2xl mx-auto text-[#d7f5ef]">
+          A curated glimpse from Facebook and Instagram showing product launches, behind-the-scenes
+          studio energy, and the community moments that keep our creative work grounded.
+        </p>
+      </div>
+
+      <div className="grid gap-10">
+        {sortedPlatforms.map((platform) => (
+          <article
+            key={platform.platform}
+            className="rounded-3xl border border-[#2f6f68]/50 bg-[#052c28]/70 p-8 shadow-[0_24px_60px_rgba(0,150,136,0.22)]"
+          >
+            <header className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-8">
+              <div>
+                <h3 className="text-2xl font-semibold text-[#a7ffeb] flex items-center gap-2">
+                  <span
+                    className={`inline-flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br ${platformColor[platform.platform]} text-white shadow-[0_12px_26px_rgba(0,150,136,0.25)]`}
+                    aria-hidden="true"
+                  >
+                    {platform.platform === 'facebook' ? 'f' : 'ig'}
+                  </span>
+                  {platform.displayName}
+                </h3>
+                <p className="text-[#9adcd1]">{platform.handle}</p>
+              </div>
+              <a
+                href={platform.photos[0]?.link ?? '#'}
+                className="inline-flex items-center gap-2 rounded-full border border-[#00bfa5]/50 bg-[#022b27]/80 px-4 py-2 text-sm font-semibold text-[#a7ffeb] transition-all duration-300 hover:-translate-y-0.5 hover:bg-[#035049]/70 hover:text-[#c8fff4]"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Visit profile
+                <span aria-hidden="true">↗</span>
+              </a>
+            </header>
+
+            <div className="grid gap-6 md:grid-cols-3">
+              {platform.photos.map((photo) => (
+                <a
+                  key={photo.id}
+                  href={photo.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group relative overflow-hidden rounded-2xl border border-[#1f655d]/50 bg-[#021c1a]/70 transition-transform duration-500 hover:-translate-y-2"
+                >
+                  <img
+                    src={photo.imageUrl}
+                    alt={photo.caption}
+                    className="h-60 w-full object-cover transition duration-500 group-hover:scale-105 group-hover:brightness-110"
+                    loading="lazy"
+                  />
+                  <div className="absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-[#021c1a]/95 via-[#021c1a]/40 to-transparent p-5 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+                    <p className="text-sm text-[#e3fbf6]">{photo.caption}</p>
+                    <span className="mt-3 text-xs font-semibold uppercase tracking-[0.3em] text-[#7fcfc2]">
+                      {formatDate(photo.timestamp)}
+                    </span>
+                  </div>
+                </a>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+
+      <div className="mt-12 grid gap-6 lg:grid-cols-[2fr,3fr]">
+        <div className="rounded-2xl border border-[#2f6f68]/50 bg-[#042623]/70 p-6">
+          <h3 className="text-lg font-semibold text-[#a7ffeb]">Connecting to the real feeds</h3>
+          <p className="mt-3 text-sm text-[#d7f5ef]">
+            Facebook and Instagram both expose APIs for pulling media, but they require secure server-side
+            tokens. You&apos;ll want to connect through the Meta Graph API (for Facebook Pages) and the
+            Instagram Basic Display or Graph API for business accounts.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-[#2f6f68]/50 bg-[#052c28]/70 p-6">
+          <h3 className="text-lg font-semibold text-[#a7ffeb]">Implementation checklist</h3>
+          <ol className="mt-3 space-y-2 text-sm text-[#d7f5ef] list-decimal list-inside">
+            <li>Create an app inside <span className="font-semibold text-[#a7ffeb]">Meta for Developers</span> and generate tokens.</li>
+            <li>Store long-lived access tokens on the server (never ship them to the browser).</li>
+            <li>Build an API route (Edge Function or serverless) that fetches media and forwards the curated JSON.</li>
+            <li>Swap the static data in <code className="rounded bg-[#021c1a]/80 px-2 py-1 text-[#7fcfc2]">social-photos.ts</code> with live responses.</li>
+          </ol>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default memo(SocialPhotosSection);

--- a/src/data/social-photos.ts
+++ b/src/data/social-photos.ts
@@ -1,0 +1,80 @@
+export interface SocialPhoto {
+  id: string;
+  platform: 'facebook' | 'instagram';
+  imageUrl: string;
+  caption: string;
+  timestamp: string;
+  link: string;
+}
+
+export interface SocialPlatformPhotos {
+  platform: 'facebook' | 'instagram';
+  displayName: string;
+  handle: string;
+  photos: SocialPhoto[];
+}
+
+export const socialPhotos: SocialPlatformPhotos[] = [
+  {
+    platform: 'facebook',
+    displayName: 'Facebook',
+    handle: '@abirabbasmd',
+    photos: [
+      {
+        id: 'fb-01',
+        platform: 'facebook',
+        imageUrl: 'https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=800&q=80',
+        caption: 'Behind the scenes from a weekend hackathon with the crew. #buildinpublic',
+        timestamp: '2024-11-08T10:15:00.000Z',
+        link: 'https://www.facebook.com/'
+      },
+      {
+        id: 'fb-02',
+        platform: 'facebook',
+        imageUrl: 'https://images.unsplash.com/photo-1454165205744-3b78555e5572?auto=format&fit=crop&w=800&q=80',
+        caption: 'Sharing the highlights from my latest mentoring session for early-stage founders.',
+        timestamp: '2024-10-22T08:45:00.000Z',
+        link: 'https://www.facebook.com/'
+      },
+      {
+        id: 'fb-03',
+        platform: 'facebook',
+        imageUrl: 'https://images.unsplash.com/photo-1446776811953-b23d57bd21aa?auto=format&fit=crop&w=800&q=80',
+        caption: 'Prototype sneak peek from a rapid iteration sprint.',
+        timestamp: '2024-09-28T18:30:00.000Z',
+        link: 'https://www.facebook.com/'
+      }
+    ]
+  },
+  {
+    platform: 'instagram',
+    displayName: 'Instagram',
+    handle: '@uknowwho_ab1r',
+    photos: [
+      {
+        id: 'ig-01',
+        platform: 'instagram',
+        imageUrl: 'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=800&q=80',
+        caption: 'Coffee-fueled design sprints with the team ☕️',
+        timestamp: '2024-12-02T14:05:00.000Z',
+        link: 'https://www.instagram.com/uknowwho_ab1r/'
+      },
+      {
+        id: 'ig-02',
+        platform: 'instagram',
+        imageUrl: 'https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=800&q=80',
+        caption: 'From sketch to shipping — capturing the product journey.',
+        timestamp: '2024-11-19T09:55:00.000Z',
+        link: 'https://www.instagram.com/uknowwho_ab1r/'
+      },
+      {
+        id: 'ig-03',
+        platform: 'instagram',
+        imageUrl: 'https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=800&q=80',
+        caption: 'Late-night UI polish before launch. ✨',
+        timestamp: '2024-10-05T21:20:00.000Z',
+        link: 'https://www.instagram.com/uknowwho_ab1r/'
+      }
+    ]
+  }
+];


### PR DESCRIPTION
## Summary
- add a Social Highlights section that showcases Facebook and Instagram photo grids and explains how to wire them up to live APIs
- introduce a reusable data shape for curated social photos and seed it with representative content
- surface the new tab in the main navigation and render it alongside the existing sections
- update the Instagram handle and outbound links to point to @uknowwho_ab1r

## Testing
- yarn lint *(fails: existing warning about unnecessary dependency in src/components/BlackBoxAssistant.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d899d15b3483268d39ae06df589ff2