### PR TITLE
Refine journey timeline entries

### DIFF
--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -25,10 +25,13 @@ const BlogSection: FC<BlogSectionProps> = ({ posts, isFetching, onRetry }) => (
     ) : posts.length > 0 ? (
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
         {posts.map((post, index) => {
-          const date = new Date(post.pubDate).toLocaleDateString('en-US', {
+          const publishedAt = new Date(post.pubDate);
+          const formattedDateTime = publishedAt.toLocaleString('en-US', {
             year: 'numeric',
             month: 'long',
-            day: 'numeric'
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit'
           });
 
           let excerpt = post.description || post.content || '';
@@ -45,7 +48,7 @@ const BlogSection: FC<BlogSectionProps> = ({ posts, isFetching, onRetry }) => (
               <h3 className="blog-title text-2xl font-semibold text-[#a7ffeb] mb-3 group-hover:text-[#c8fff4] transition-colors duration-300 tracking-wide">
                 {post.title}
               </h3>
-              <div className="blog-date text-[#9adcd1] text-sm mb-4">{date}</div>
+              <div className="blog-date text-[#9adcd1] text-sm mb-4">{formattedDateTime}</div>
               <p className="blog-excerpt text-[#d7f5ef] mb-6 leading-relaxed">{excerpt}</p>
               <a
                 href={post.link}

--- a/src/data/journey.ts
+++ b/src/data/journey.ts
@@ -6,14 +6,21 @@ export interface JourneyStep {
 
 export const journey: JourneyStep[] = [
   {
+    year: '2025',
+    title: 'Rust Evangelist & Security Specialist',
+    description:
+      'Reverse engineering various Rust frameworks to understand how to build high performant systems in Rust and mapping out tools like ShadowMap in Rust & Agents.'
+  },
+  {
     year: '2024',
     title: 'AI Alchemist & Vibe Coder',
     description: 'Mastering the art of turning data into gold with advanced AI systems, prompt engineering, and building lovable, secure websites.'
   },
   {
     year: '2023',
-    title: 'Rust Evangelist & Security Specialist',
-    description: 'Building high-performance systems with Rust and creating security tools like ShadowMap for the open-source community.'
+    title: 'Mindset Mentor & Community Builder',
+    description:
+      'Growing our mindset and expanding our vision possibility with agents. We started building our technical blog and mentoring to build our skillset.'
   },
   {
     year: '2022',


### PR DESCRIPTION
## Summary
- separate the 2025 Rust journey milestone from a new 2023 mindset and mentoring entry
- capture the requested agents-focused description for 2025 and the technical blog mentoring focus for 2023

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9657044e88326a15c28653dd81d20