### PR TITLE
Rename blog and tutorial sections to Thoughts and Video Writeups

### DIFF
--- a/src/artifact-component.tsx
+++ b/src/artifact-component.tsx
@@ -250,7 +250,7 @@ const ArtifactComponent = () => {
     (tab: string) => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
       setActiveTab(tab);
-      if (tab === 'blog' && mediumPosts.length === 0) {
+      if (tab === 'thoughts' && mediumPosts.length === 0) {
         fetchMediumPosts();
       }
     },
@@ -288,11 +288,11 @@ const ArtifactComponent = () => {
         )}
         {activeTab === 'skills' && <SkillsSection skills={skills} />}
         {activeTab === 'projects' && <ProjectsSection projects={projects} />}
-        {activeTab === 'blog' && (
+        {activeTab === 'thoughts' && (
           <BlogSection posts={mediumPosts} isFetching={isFetchingPosts} onRetry={fetchMediumPosts} />
         )}
         {activeTab === 'social' && <SocialPhotosSection platforms={socialPhotos} />}
-        {activeTab === 'tutorials' && <TutorialsSection />}
+        {activeTab === 'video-writeups' && <TutorialsSection />}
         {activeTab === 'services' && (
           <ServicesSection services={services} bookMeeting={bookMeeting} />
         )}

--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -11,10 +11,10 @@ interface BlogSectionProps {
 const BlogSection: FC<BlogSectionProps> = ({ posts, isFetching, onRetry }) => (
   <section className="mb-16 animate-fadeIn">
     <h2 className="text-4xl font-bold text-center mb-4 bg-gradient-to-r from-[#c8fff4] via-[#4DB6AC] to-[#009688] bg-clip-text text-transparent drop-shadow-[0_16px_40px_rgba(0,150,136,0.25)]">
-      My Medium Blog Posts
+      Thoughts
     </h2>
     <p className="text-xl text-[#d7f5ef] text-center mb-12 max-w-3xl mx-auto">
-      Sharing my thoughts on AI, Rust, security, and vibe coding.
+      Sharing reflective notes on AI, Rust, security, and vibe coding.
     </p>
 
     {isFetching ? (
@@ -64,7 +64,7 @@ const BlogSection: FC<BlogSectionProps> = ({ posts, isFetching, onRetry }) => (
       </div>
     ) : (
       <div className="text-center py-12">
-        <p className="text-[#9adcd1] text-lg">No blog posts available at the moment.</p>
+        <p className="text-[#9adcd1] text-lg">No thoughts available at the moment.</p>
         <button
           onClick={onRetry}
           className="mt-4 bg-gradient-to-r from-[#00a99d] via-[#4DB6AC] to-[#00bfa5] hover:from-[#009688] hover:via-[#00a99d] hover:to-[#4DB6AC] text-[#052321] font-semibold tracking-wide py-2 px-4 rounded-lg transition-all duration-300 shadow-[0_16px_32px_rgba(0,150,136,0.3)]"
@@ -82,7 +82,7 @@ const BlogSection: FC<BlogSectionProps> = ({ posts, isFetching, onRetry }) => (
         className="inline-block bg-gradient-to-r from-[#00a99d] via-[#4DB6AC] to-[#00bfa5] hover:from-[#009688] hover:via-[#00a99d] hover:to-[#4DB6AC] text-[#052321] font-semibold tracking-wide py-3 px-6 rounded-lg border border-[#00bfa5]/40 transition-all duration-300 shadow-[0_20px_45px_rgba(0,150,136,0.35)] hover:-translate-y-0.5"
         onClick={onRetry}
       >
-        View All Posts on Medium →
+        View All Thoughts on Medium →
       </a>
     </div>
   </section>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,8 +6,16 @@ interface NavigationProps {
 }
 
 const tabs = [
-  'home', 'skills', 'projects', 'blog', 'tutorials',
-  'services', 'awards', 'experience', 'journey', 'contact'
+  { id: 'home', label: 'Home' },
+  { id: 'skills', label: 'Skills' },
+  { id: 'projects', label: 'Projects' },
+  { id: 'thoughts', label: 'Thoughts' },
+  { id: 'video-writeups', label: 'Video Writeups' },
+  { id: 'services', label: 'Services' },
+  { id: 'awards', label: 'Awards' },
+  { id: 'experience', label: 'Experience' },
+  { id: 'journey', label: 'Journey' },
+  { id: 'contact', label: 'Contact' }
 ];
 
 const Navigation: FC<NavigationProps> = ({ activeTab, onTabClick }) => {
@@ -45,17 +53,17 @@ const Navigation: FC<NavigationProps> = ({ activeTab, onTabClick }) => {
     <nav className="flex flex-wrap justify-center gap-4 mb-12 relative" aria-label="Primary">
       {tabs.map((tab) => (
         <button
-          key={tab}
+          key={tab.id}
           type="button"
-          onClick={() => onTabClick(tab)}
-          aria-current={activeTab === tab ? 'page' : undefined}
+          onClick={() => onTabClick(tab.id)}
+          aria-current={activeTab === tab.id ? 'page' : undefined}
           className={`tab px-6 py-3 rounded-lg font-bold transition-all duration-200 ease-out motion-reduce:transition-none border-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 focus-visible:ring-offset-2 ${
-            activeTab === tab
+            activeTab === tab.id
               ? 'text-green-400 border-green-400 bg-green-400/20 shadow-lg shadow-green-400/30'
               : 'text-gray-400 border-gray-600 hover:border-cyan-400 hover:text-cyan-400'
           }`}
         >
-          {tab.charAt(0).toUpperCase() + tab.slice(1)}
+          {tab.label}
         </button>
       ))}
 

--- a/src/components/TutorialsSection.tsx
+++ b/src/components/TutorialsSection.tsx
@@ -52,10 +52,10 @@ const TutorialsSection: FC = () => {
   return (
     <section className="mb-16 animate-fadeIn">
       <h2 className="text-4xl font-bold text-center mb-4 bg-gradient-to-r from-[#c8fff4] via-[#4DB6AC] to-[#009688] bg-clip-text text-transparent drop-shadow-[0_16px_40px_rgba(0,150,136,0.25)]">
-        Tutorials
+        Video Writeups
       </h2>
       <p className="text-xl text-[#d7f5ef] text-center mb-12 max-w-3xl mx-auto">
-        Tutorials highlighting our AI-augmented thinking and projects.
+        Bite-sized video writeups highlighting our AI-augmented thinking and projects.
       </p>
       <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
         {videos.map((video) => (
@@ -82,7 +82,7 @@ const TutorialsSection: FC = () => {
           rel="noopener noreferrer"
           className="inline-block bg-gradient-to-r from-[#00a99d] via-[#4DB6AC] to-[#00bfa5] hover:from-[#009688] hover:via-[#00a99d] hover:to-[#4DB6AC] text-[#052321] font-semibold tracking-wide py-3 px-6 rounded-lg border border-[#00bfa5]/40 transition-all duration-300 shadow-[0_20px_45px_rgba(0,150,136,0.35)] hover:-translate-y-0.5"
         >
-          View All Tutorials on YouTube →
+          View All Video Writeups on YouTube →
         </a>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- update navigation tabs to display "Thoughts" and "Video Writeups" while aligning underlying identifiers
- refresh blog section copy to reflect the "Thoughts" rebranding, including empty states and links
- retitle the tutorials view and supporting copy to position it as "Video Writeups"

## Testing
- yarn lint *(fails: missing node_modules state file; install required)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690c44596f30832686b75c56b42e17fe)